### PR TITLE
Update region roles for new regions

### DIFF
--- a/commands/giveroles.js
+++ b/commands/giveroles.js
@@ -117,16 +117,13 @@ module.exports = {
                   }
                   switch (parseInt(data.data.facility.info.region)) {
                     case 5:
-                      roles.push('Southern Region')
+                      roles.push('Central Region')
                       break
                     case 6:
-                      roles.push('Midwestern Region')
+                      roles.push('Western Region')
                       break
                     case 7:
-                      roles.push('Northeastern Region')
-                      break
-                    case 8:
-                      roles.push('Western Region')
+                      roles.push('Eastern Region')
                       break
                   }
                 }).catch(error => {


### PR DESCRIPTION
This will require updating the region roles in the Discord to work properly, but accounts for new regions when assigning roles.